### PR TITLE
stdext. defaults. optional ec2 key. conditions from azs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ cfhighlander cfcompile --validate ecs
 
 ### Parameters
 
-TBD
+`SecurityGroupLoadBalancer` - Group allowed to access ECS Cluster 
 
 ### Configuration options
 

--- a/ecs.cfhighlander.rb
+++ b/ecs.cfhighlander.rb
@@ -1,18 +1,18 @@
 CfhighlanderTemplate do
-  DependsOn 'vpc@1.2.0'
+  DependsOn stdext
   Parameters do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
     ComponentParam 'EnvironmentType', 'development', isGlobal: true
     ComponentParam 'Ami', type: 'AWS::EC2::Image::Id'
-    MappingParam('InstanceType') do
+    MappingParam('InstanceType', 't2.medium') do
       map 'EnvironmentType'
       attribute 'EcsInstanceType'
     end
-    MappingParam('AsgMin') do
+    MappingParam('AsgMin', 1) do
       map 'EnvironmentType'
       attribute 'EcsAsgMin'
     end
-    MappingParam('AsgMax') do
+    MappingParam('AsgMax', 1) do
       map 'EnvironmentType'
       attribute 'EcsAsgMax'
     end
@@ -27,6 +27,10 @@ CfhighlanderTemplate do
 
     maximum_availability_zones.times do |az|
       ComponentParam "SubnetCompute#{az}"
+      MappingParam "Az#{az}" do
+        map 'AzMappings'
+        attribute "Az#{az}"
+      end
     end
 
     ComponentParam 'VPCId', type: 'AWS::EC2::VPC::Id'

--- a/ecs.cfndsl.rb
+++ b/ecs.cfndsl.rb
@@ -69,12 +69,14 @@ CloudFormation do
     user_data << ".amazonaws.com:/ /efs\n"
   end
 
+  Condition('LaunchConfigKeySet', FnNot(FnEquals(Ref('KeyName'),'')))
+
   LaunchConfiguration('LaunchConfig') do
     ImageId Ref('Ami')
     InstanceType Ref('InstanceType')
     AssociatePublicIpAddress false
     IamInstanceProfile Ref('InstanceProfile')
-    KeyName Ref('KeyName')
+    KeyName FnIf('LaunchConfigKeySet', Ref('KeyName'), Ref('AWS::NoValue'))
     SecurityGroups [ Ref('SecurityGroupEcs') ]
     UserData FnBase64(FnJoin('',user_data))
   end

--- a/ecs.config.yaml
+++ b/ecs.config.yaml
@@ -1,3 +1,5 @@
+stdext: github:toshke/hl-component-stdext
+
 maximum_availability_zones: 5
 
 # cluster name is prefixed with environment name


### PR DESCRIPTION
# DO NOT MERGE UNTIL REFERENCE TO STDEXT IS RESOLVED 

## Improvements

### Default parameter values

Just pulling in ECS component should require no know-how configuration - should work outside of the box. In combination with cfhighlander PR enabling `MappingParam` to behave is standard parameter if no value is given, this PR sets some sane default values. 

### Standard extensions

Rather then depending on VPC component for helper methods, they are extracted into "standard extensions" (stdext). https://github.com/toshke/hl-component-stdext . Standard extensions component name is parameterized. 

### EC2 Key is optional

Access to EC2 bastion instance can be allowed through UserData, not only through KeyPair. This PR allows configuration with no key pair set. 