### PR TITLE
ecs draining with rolling updates

### DIFF
--- a/ecs.cfhighlander.rb
+++ b/ecs.cfhighlander.rb
@@ -6,7 +6,7 @@ CfhighlanderTemplate do
     ComponentParam 'Ami', type: 'AWS::EC2::Image::Id'
     ComponentParam 'EnableScaling', 'false', allowedValues: ['true','false']
     ComponentParam 'SpotPrice', ''
-    
+
     MappingParam('InstanceType') do
       map 'EnvironmentType'
       attribute 'EcsInstanceType'
@@ -38,4 +38,7 @@ CfhighlanderTemplate do
     ComponentParam 'FileSystem' if enable_efs
 
   end
+
+  LambdaFunctions 'ecs_contianer_instance_draining'
+  
 end

--- a/ecs.config.yaml
+++ b/ecs.config.yaml
@@ -11,11 +11,11 @@ maximum_availability_zones: 5
 #   ECS_IMAGE_CLEANUP_INTERVAL: 10m
 #   ECS_IMAGE_MINIMUM_CLEANUP_AGE: 5m
 
-# asg_update_policy:
-#   AutoScalingRollingUpdate:
-#     MaxBatchSize: 1
-#     MinInstancesInService: 1
-#     SuspendProcesses: ["HealthCheck","ReplaceUnhealthy","AZRebalance","AlarmNotification","ScheduledActions"]
+asg_update_policy:
+  AutoScalingRollingUpdate:
+    MaxBatchSize: 1
+    MinInstancesInService: 1
+    SuspendProcesses: ["HealthCheck","ReplaceUnhealthy","AZRebalance","AlarmNotification","ScheduledActions"]
 
 # volume_size: 20
 
@@ -59,3 +59,39 @@ iam_policies:
       - elasticloadbalancing:Describe*
       - elasticloadbalancing:RegisterInstancesWithLoadBalancer
       - elasticloadbalancing:RegisterTargets
+
+ecs_contianer_instance_draining:
+  custom_policies:
+    ecs:
+      action:
+        - ecs:ListContainerInstances
+        - ecs:SubmitContainerStateChange
+        - ecs:SubmitTaskStateChange
+        - ecs:DescribeContainerInstances
+        - ecs:UpdateContainerInstancesState
+        - ecs:ListTasks
+        - ecs:DescribeTasks
+      resource: '*'
+    ec2:
+      action:
+        - autoscaling:CompleteLifecycleAction
+        - ec2:DescribeInstances
+        - ec2:DescribeInstanceAttribute
+        - ec2:DescribeInstanceStatus
+        - ec2:DescribeHosts
+      resource: '*'
+  roles:
+    EcsContainerInstanceDraining:
+      policies_inline:
+        - ec2
+        - ecs
+  functions:
+    EcsContainerInstanceDraining:
+      code: ecs_contianer_instance_draining.py
+      handler: ecs_contianer_instance_draining.lambda_handler
+      runtime: python3.6
+      timeout: 310
+      role: EcsContainerInstanceDraining
+      environment:
+        CLUSTER:
+          Ref: EcsCluster

--- a/lambdas/ecs_contianer_instance_draining.py
+++ b/lambdas/ecs_contianer_instance_draining.py
@@ -1,0 +1,73 @@
+import boto3, json, os, time
+
+
+ecs = boto3.client('ecs')
+
+autoscaling = boto3.client('autoscaling')
+
+
+
+def lambda_handler(event, context):
+  print(json.dumps(event))
+  cluster = os.environ['CLUSTER']
+  snsTopicArn = event['Records'][0]['Sns']['TopicArn']
+  lifecycle_event = json.loads(event['Records'][0]['Sns']['Message'])
+  instance_id = lifecycle_event.get('EC2InstanceId')
+  if not instance_id:
+    print('Got event without EC2InstanceId: %s', json.dumps(event))
+    return
+
+  instance_arn = container_instance_arn(cluster, instance_id)
+  print('Instance %s has container instance ARN %s' % (lifecycle_event['EC2InstanceId'], instance_arn))
+
+  if not instance_arn:
+    return
+
+  while has_tasks(cluster, instance_arn):
+    time.sleep(10)
+
+  try:
+    print('Terminating instance %s' % instance_id)
+    autoscaling.complete_lifecycle_action(
+        LifecycleActionResult='CONTINUE',
+        **pick(lifecycle_event, 'LifecycleHookName', 'LifecycleActionToken', 'AutoScalingGroupName'))
+  except Exception as e:
+    # Lifecycle action may have already completed.
+    print(str(e))
+
+
+def container_instance_arn(cluster, instance_id):
+  """Turn an instance ID into a container instance ARN."""
+  arns = ecs.list_container_instances(cluster=cluster, filter='ec2InstanceId==' + instance_id)['containerInstanceArns']
+  if not arns:
+    return None
+  return arns[0]
+
+
+def has_tasks(cluster, instance_arn):
+  """Return True if the instance is running tasks for the given cluster."""
+  instances = ecs.describe_container_instances(cluster=cluster, containerInstances=[instance_arn])['containerInstances']
+  if not instances:
+    return False
+  instance = instances[0]
+
+  if instance['status'] == 'ACTIVE':
+    # Start draining, then try again later
+    set_container_instance_to_draining(cluster, instance_arn)
+    return True
+
+  tasks = instance['runningTasksCount'] + instance['pendingTasksCount']
+  print('Instance %s has %s tasks' % (instance_arn, tasks))
+
+  return tasks > 0
+
+
+def set_container_instance_to_draining(cluster, instance_arn):
+  ecs.update_container_instances_state(
+      cluster=cluster,
+      containerInstances=[instance_arn], status='DRAINING')
+
+
+def pick(dct, *keys):
+  """Pick a subset of a dict."""
+  return {k: v for k, v in dct.items() if k in keys}


### PR DESCRIPTION
created a lambda function to drain the instances from a termination lifecycle hook.
is always deployed