### PR TITLE
Removed dependency on VPC component

### DIFF
--- a/ecs.cfhighlander.rb
+++ b/ecs.cfhighlander.rb
@@ -1,11 +1,11 @@
 CfhighlanderTemplate do
-  DependsOn 'vpc@1.2.0'
   Parameters do
     ComponentParam 'EnvironmentName', 'dev', isGlobal: true
     ComponentParam 'EnvironmentType', 'development', isGlobal: true
     ComponentParam 'Ami', type: 'AWS::EC2::Image::Id'
     ComponentParam 'EnableScaling', 'false', allowedValues: ['true','false']
     ComponentParam 'SpotPrice', ''
+    ComponentParam 'SubnetIds', type: 'CommaDelimitedList'
     
     MappingParam('InstanceType') do
       map 'EnvironmentType'

--- a/ecs.cfndsl.rb
+++ b/ecs.cfndsl.rb
@@ -2,8 +2,6 @@ CloudFormation do
 
   Description "#{component_name} - #{component_version}"
 
-  az_conditions_resources('SubnetCompute', maximum_availability_zones)
-
   Condition('IsScalingEnabled', FnEquals(Ref('EnableScaling'), 'true'))
   Condition("SpotPriceSet", FnNot(FnEquals(Ref('SpotPrice'), '')))
 
@@ -121,7 +119,7 @@ CloudFormation do
     HealthCheckGracePeriod '500'
     MinSize Ref('AsgMin')
     MaxSize Ref('AsgMax')
-    VPCZoneIdentifier az_conditional_resources('SubnetCompute', maximum_availability_zones)
+    VPCZoneIdentifier Ref('SubnetIds')
     Tags asg_ecs_tags
   end
 


### PR DESCRIPTION
Pass list of subnets to component instead of depending on AZ functions from VPC component.

VPC v1.6.2+ outputs subnet ids as comma separated lists, this can be passed to the SubnetIds param. eg:

```
Component template: 'ecs', name: 'ecs' do
    parameter name: 'SubnetIds', value: 'vpc.ComputeSubnets'
  end
```